### PR TITLE
Updated Configuration Documentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -3,7 +3,7 @@
 When a peak project is instantiated, `.peakconfig.yml` is generated in the project root to house your project configuration.  These configuration options are available:
 
 ```yaml
-blog:      # Your Tumblr blog name (e.g. myblog.tumblr.com).
+blog:      # Your Tumblr blog name (without the tumblr.com i.e. wqxyz if your blog is wqxyz.tumblr.com).
 email:     # The e-mail address used to sign into Tumblr; used for deployment.
 password:  # The password used to sign into Tumblr; used for deployment.
 index:     # The path (relative to root) to the main theme; the theme to be deployed to tumblr; used as the watcher's index.  Defaults to `index.ext`.


### PR DESCRIPTION
Slightly verbose clarification to specify use of just the subdomain for the `blog:` parameter, to avoid confusion that could arise from the existing description.